### PR TITLE
feat(polls): pollsアプリケーションにテストを追加

### DIFF
--- a/polls/models.py
+++ b/polls/models.py
@@ -4,20 +4,24 @@ from django.db import models
 from django.utils import timezone
 
 # Create your models here.
-class Question(models.Model):
-  question_text = models.CharField(max_length=200)
-  pub_date = models.DateTimeField('date published')
 
-  def __str__(self):
-    return self.question_text
-  
-  def was_published_recently(self):
-    return self.pub_date >= timezone.now() - datetime.timedelta(days=1)
+
+class Question(models.Model):
+    question_text = models.CharField(max_length=200)
+    pub_date = models.DateTimeField('date published')
+
+    def __str__(self):
+        return self.question_text
+
+    def was_published_recently(self):
+        now = timezone.now()
+        return now - datetime.timedelta(days=1) <= self.pub_date <= now
+
 
 class Choice(models.Model):
-  question = models.ForeignKey(Question,on_delete=models.CASCADE)
-  choice_text = models.CharField(max_length=200)
-  votes = models.IntegerField(default=0)
+    question = models.ForeignKey(Question, on_delete=models.CASCADE)
+    choice_text = models.CharField(max_length=200)
+    votes = models.IntegerField(default=0)
 
-  def __str__(self):
-    return self.choice_text
+    def __str__(self):
+        return self.choice_text

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -29,3 +29,11 @@ class QuestionModelTests(TestCase):
 def create_question(question_text, days):
     time = timezone.now() + datetime.timedelta(days=days)
     return Question.objects.create(question_text=question_text, pub_date=time)
+
+
+class QuestionIndexViewTests(TestCase):
+    def test_no_questions(self):
+        reponse = self.client.get(reverse('polls:index'))
+        self.assertEqueal(response.status_code, 200)
+        self.assertContains(response, "No polls are available")
+        self.assertQuerysetEqual(response.context["latest_question_list"])

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -37,3 +37,11 @@ class QuestionIndexViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "No polls are available")
         self.assertQuerysetEqual(response.context["latest_question_list"], [])
+
+    def test_past_question(self):
+        question = create_question(question_text="Past question.", days=-30)
+        response = self.client.get(reverse('polls:index'))
+        self.assertQuerysetEqual(
+            response.context['latest_question_list'],
+            [question],
+        )

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -1,3 +1,15 @@
-from django.test import TestCase
+import datetime
 
+from django.test import TestCase
+from django.utils import timezone
+
+from .models import Question
 # Create your tests here.
+
+
+class QuestionModelTests(TestCase):
+
+    def test_was_published_recently_with_future_question(self):
+        time = timezone.now() + datetime.timedelta(days=30)
+        future_question = Question(pub_date=time)
+        self.assertIs(future_question.was_published_recently(), False)

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -13,3 +13,13 @@ class QuestionModelTests(TestCase):
         time = timezone.now() + datetime.timedelta(days=30)
         future_question = Question(pub_date=time)
         self.assertIs(future_question.was_published_recently(), False)
+
+    def test_was_published_recently_with_old_question(self):
+        time = timezone.now() - datetime.timedelta(days=1, seconds=1)
+        old_question = Question(pub_date=time)
+        self.assertIs(old_question.was_published_recently(), False)
+
+    def test_was_published_recently_with_recent_question(self):
+        time = timezone.now() - datetime.timedelta(hours=23, minutes=59, seconds=59)
+        recent_question = Question(pub_date=time)
+        self.assertIs(recent_question.was_published_recently(), True)

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -52,3 +52,15 @@ class QuestionIndexViewTests(TestCase):
         response = self.client.get(reverse('polls:index'))
         self.assertQuerysetEqual(response.context['latest_question_list'],
                                  [question])
+
+    def test_two_past_questions(self):
+        """
+        The questions index page may display multiple questions.
+        """
+        question1 = create_question(question_text="Past question 1.", days=-30)
+        question2 = create_question(question_text="Past question 2.", days=-5)
+        response = self.client.get(reverse('polls:index'))
+        self.assertQuerysetEqual(
+            response.context['latest_question_list'],
+            [question2, question1],
+        )

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -45,3 +45,10 @@ class QuestionIndexViewTests(TestCase):
             response.context['latest_question_list'],
             [question],
         )
+
+    def test_future_question_and_past_question(self):
+        question = create_question(question_text="Past question.", days=-30)
+        create_question(question_text="Future question.", days=30)
+        response = self.client.get(reverse('polls:index'))
+        self.assertQuerysetEqual(response.context['latest_question_list'],
+                                 [question])

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -64,3 +64,27 @@ class QuestionIndexViewTests(TestCase):
             response.context['latest_question_list'],
             [question2, question1],
         )
+
+
+class QuestionDetailViewTests(TestCase):
+    def test_future_question(self):
+        """
+        The detail view of a question with a pub_date in the future
+        returns a 404 not found.
+        """
+        future_question = create_question(
+            question_text='Future question.', days=5)
+        url = reverse('polls:detail', args=(future_question.id,))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_past_question(self):
+        """
+        The detail view of a question with a pub_date in the past
+        displays the question's text.
+        """
+        past_question = create_question(
+            question_text='Past Question.', days=-5)
+        url = reverse('polls:detail', args=(past_question.id,))
+        response = self.client.get(url)
+        self.assertContains(response, past_question.question_text)

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.test import TestCase
 from django.utils import timezone
-from djnago.urls import reverse
+from django.urls import reverse
 
 from .models import Question
 # Create your tests here.
@@ -33,7 +33,7 @@ def create_question(question_text, days):
 
 class QuestionIndexViewTests(TestCase):
     def test_no_questions(self):
-        reponse = self.client.get(reverse('polls:index'))
-        self.assertEqueal(response.status_code, 200)
+        response = self.client.get(reverse('polls:index'))
+        self.assertEqual(response.status_code, 200)
         self.assertContains(response, "No polls are available")
-        self.assertQuerysetEqual(response.context["latest_question_list"])
+        self.assertQuerysetEqual(response.context["latest_question_list"], [])

--- a/polls/tests.py
+++ b/polls/tests.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.test import TestCase
 from django.utils import timezone
+from djnago.urls import reverse
 
 from .models import Question
 # Create your tests here.
@@ -23,3 +24,8 @@ class QuestionModelTests(TestCase):
         time = timezone.now() - datetime.timedelta(hours=23, minutes=59, seconds=59)
         recent_question = Question(pub_date=time)
         self.assertIs(recent_question.was_published_recently(), True)
+
+
+def create_question(question_text, days):
+    time = timezone.now() + datetime.timedelta(days=days)
+    return Question.objects.create(question_text=question_text, pub_date=time)

--- a/polls/views.py
+++ b/polls/views.py
@@ -23,6 +23,9 @@ class DetailView(generic.DetailView):
     model = Question
     template_name = 'polls/detail.html'
 
+    def get_queryset(self):
+        return Question.objects.filter(pub_date__lte=timezone.now())
+
 
 class ResultsView(generic.DetailView):
     model = Question

--- a/polls/views.py
+++ b/polls/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.views import generic
-from djnago.utils import timezone
+from django.utils import timezone
 
 from .models import Question, Choice
 # Create your views here.

--- a/polls/views.py
+++ b/polls/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.views import generic
+from djnago.utils import timezone
 
 from .models import Question, Choice
 # Create your views here.
@@ -13,7 +14,9 @@ class IndexView(generic.ListView):
 
     def get_queryset(self):
         """Return the last five published questions."""
-        return Question.objects.order_by('-pub_date')[:5]
+        return Question.objects.filter(
+            pub_date__lte=timezone.now()
+        ).order_by('-pub_date')[:5]
 
 
 class DetailView(generic.DetailView):


### PR DESCRIPTION
## 概要
[Djangoアプリの作成5](https://docs.djangoproject.com/ja/3.2/intro/tutorial05/)を完了

## 要件
* 投稿記事が未来に投稿されたものは最近投稿されたものにカウントしないかテスト & 修正
* 質問が投稿されている場合といない場合でのテンプレートのテストを追加
